### PR TITLE
Add block plugin validator classes and form

### DIFF
--- a/bin/check-block.php
+++ b/bin/check-block.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace WordPressdotorg\Plugin_Directory;
+
+use WordPressdotorg\Plugin_Directory\CLI\Block_Plugin_Checker;
+
+// This script should only be called in a CLI environment.
+if ( 'cli' != php_sapi_name() ) {
+	die();
+}
+
+$opts = getopt( '', array( 'post:', 'url:', 'abspath:', 'slug:', 'all' ) );
+
+if ( empty( $opts['url'] ) ) {
+	$opts['url'] = 'https://wordpress.org/plugins/';
+}
+if ( empty( $opts['abspath'] ) && false !== strpos( __DIR__, 'wp-content' ) ) {
+	$opts['abspath'] = substr( __DIR__, 0, strpos( __DIR__, 'wp-content' ) );
+}
+
+// Bootstrap WordPress
+$_SERVER['HTTP_HOST']   = parse_url( $opts['url'], PHP_URL_HOST );
+$_SERVER['REQUEST_URI'] = parse_url( $opts['url'], PHP_URL_PATH );
+
+require rtrim( $opts['abspath'], '/' ) . '/wp-load.php';
+
+if ( ! class_exists( '\WordPressdotorg\Plugin_Directory\Plugin_Directory' ) ) {
+	fwrite( STDERR, "Error! This site doesn't have the Plugin Directory plugin enabled.\n" );
+	if ( defined( 'WPORG_PLUGIN_DIRECTORY_BLOGID' ) ) {
+		fwrite( STDERR, "Run the following command instead:\n" );
+		fwrite( STDERR, "\tphp " . implode( ' ', $argv ) . ' --url ' . get_site_url( WPORG_PLUGIN_DIRECTORY_BLOGID, '/' ) . "\n" );
+	}
+	die();
+}
+
+function fetch_plugin( $slug, $stable_tag = null ) {
+	printf( "%s\n", $plugin->slug );
+	
+	$path = uniqid( "/tmp/blockplugin" ) . '-' . $slug;
+
+	if ( file_exists( $path ) )
+		return false;
+
+	if ( $stable_tag && 'trunk' !== $stable_tag )
+		$subdir = '/tags/' . $stable_tag;
+	else
+		$subdir = '/trunk';
+
+	$cmd = "svn export " . escapeshellarg( "https://plugins.svn.wordpress.org/" . $slug . $subdir ) . " " . escapeshellarg( $path );
+	shell_exec( $cmd );
+
+	return $path;
+}
+
+if ( !empty( $opts['slug'] ) ) {
+	$args = array(
+		'post_type' => 'plugin',
+		'post_status' => 'publish',
+		'posts_per_page' => 1,
+		'name' => $opts['slug'],
+		'tax_query' => array(
+			array(
+				'taxonomy' => 'plugin_section',
+				'field'    => 'slug',
+				'terms'    => 'block',
+			),
+		),
+	);
+} else {
+
+	$args = array(
+		'post_type' => 'plugin',
+		'post_status' => 'publish',
+		'nopaging' => true,
+		'tax_query' => array(
+			array(
+				'taxonomy' => 'plugin_section',
+				'field'    => 'slug',
+				'terms'    => 'block',
+			),
+		),
+	);
+}
+$query = new \WP_Query( $args );
+
+$count_plugins = $count_new_plugins = $count_checked = $count_blocks = $count_block_json = 0;
+#var_dump( $query );
+#
+while ( $query->have_posts() ) {
+	++ $count_checked;
+	$query->the_post();
+	$plugin = get_post();
+
+	echo "Checking $plugin->post_name\n";
+
+	$path = fetch_plugin( $plugin->post_name, $plugin->stable_tag );
+
+	$checker = new Block_Plugin_Checker( $plugin->post_name );
+	$results = $checker->run_check_plugin_files( $path );
+
+	foreach ( $results as $item ) {
+		echo "$item->type\t$item->check_name\t$item->message\n";
+		if ( $item->data ) {
+			print_r( $item->data );
+			echo "\n";
+		}
+	}
+
+	shell_exec( 'rm -rf ' . escapeshellarg( $path ) );
+}
+
+echo "Checked: " . number_format( $count_checked) . "\n";

--- a/block-json/block.json
+++ b/block-json/block.json
@@ -1,0 +1,34 @@
+{
+	"name": "my-plugin/notice",
+	"title": "Notice",
+	"category": "text",
+	"parent": [ "core/group" ],
+	"icon": "star",
+	"description": "Shows warning, error or success notices  ...",
+	"keywords": [ "alert", "message" ],
+	"textdomain": "my-plugin",
+	"attributes": {
+		"message": {
+			"type": "string",
+			"source": "html",
+			"selector": ".message"
+		}
+	},
+	"supports": {
+		"align": true,
+		"lightBlockWrapper": true
+	},
+	"styles": [
+		{ "name": "default", "label": "Default", "isDefault": true },
+		{ "name": "other", "label": "Other" }
+	],
+	"example": {
+		"attributes": {
+			"message": "This is a notice!"
+		}
+	},
+	"editorScript": "build/editor.js",
+	"script": "build/main.js",
+	"editorStyle": "build/editor.css",
+	"style": "build/style.css"
+}

--- a/block-json/class-parser.php
+++ b/block-json/class-parser.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace WordPressdotorg\Plugin_Directory\Block_JSON;
+
+use WP_Error;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Parser
+ *
+ * @package WordPressdotorg\Plugin_Directory\Block_JSON
+ */
+class Parser {
+	/**
+	 * A location resource must be pointing to a file named this.
+	 *
+	 * @const string
+	 */
+	const REQUIRED_FILENAME = 'block.json';
+
+	/**
+	 * Parse the JSON content of a given resource into a PHP object.
+	 *
+	 * @param array $resource An associative array with one item where the key specifies the type of resource and the
+	 *                        value represents the resource as a string. Valid types are `url`, `file`, and `content`.
+	 *                        In this case, the value of `content` is expected to be a raw string of JSON, while the
+	 *                        other two are expected to be the location of a file containing the JSON.
+	 *
+	 * @return object|WP_Error An object if the parse was successful, otherwise a WP_Error.
+	 */
+	public static function parse( array $resource ) {
+		reset( $resource );
+		$type   = key( $resource );
+		$handle = current( $resource );
+
+		switch ( $type ) {
+			case 'url':
+				$content = self::extract_content_from_url( $handle );
+				break;
+			case 'file':
+				$content = self::extract_content_from_file( $handle );
+				break;
+			case 'content':
+				$content = $handle;
+				break;
+			default:
+				$content = new WP_Error(
+					'no_valid_resource',
+					__( 'No valid resource type was given.', 'wporg-plugins' )
+				);
+				break;
+		}
+
+		if ( is_wp_error( $content ) ) {
+			return $content;
+		}
+
+		return self::parse_content( $content );
+	}
+
+	/**
+	 * Get the contents of a block.json file via an HTTP request to a URL.
+	 *
+	 * @param string $url
+	 *
+	 * @return string|WP_Error
+	 */
+	protected static function extract_content_from_url( $url ) {
+		$url = esc_url_raw( $url );
+
+		$filename_length = strlen( self::REQUIRED_FILENAME );
+		if ( strtolower( substr( $url, - $filename_length ) ) !== self::REQUIRED_FILENAME ) {
+			return new WP_Error(
+				'resource_url_invalid',
+				sprintf(
+					/* translators: %s: file name */
+					__( 'URL must end in %s!', 'wporg-plugins' ),
+					'<code>' . self::REQUIRED_FILENAME . '</code>'
+				)
+			);
+		}
+
+		$response      = wp_safe_remote_get( $url );
+		$response_code = wp_remote_retrieve_response_code( $response );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		} elseif ( 200 !== $response_code ) {
+			return new WP_Error(
+				'resource_url_unexpected_response',
+				__( 'URL returned an unexpected status code.', 'wporg-plugins' ),
+				array(
+					'status' => $response_code,
+				)
+			);
+		}
+
+		return wp_remote_retrieve_body( $response );
+	}
+
+	/**
+	 * Get the contents of a block.json file via a path in the filesystem.
+	 *
+	 * @param string $file
+	 *
+	 * @return string|WP_Error
+	 */
+	protected static function extract_content_from_file( $file ) {
+		$filename_length = strlen( self::REQUIRED_FILENAME );
+		if ( strtolower( substr( $file, - $filename_length ) ) !== self::REQUIRED_FILENAME ) {
+			return new WP_Error(
+				'resource_file_invalid',
+				sprintf(
+					/* translators: %s: file name */
+					__( 'File must be named %s!', 'wporg-plugins' ),
+					'<code>' . self::REQUIRED_FILENAME . '</code>'
+				)
+			);
+		}
+
+		if ( ! is_readable( $file ) ) {
+			return new WP_Error(
+				'resource_file_unreadable',
+				__( 'The file could not be read.', 'wporg-plugins' ),
+				array(
+					'file' => $file,
+				)
+			);
+		}
+
+		$content = file_get_contents( $file );
+
+		if ( false === $content ) {
+			return new WP_Error(
+				'resource_file_failed_retrieval',
+				__( 'Could not get the contents of the file.', 'wporg-plugins' ),
+				array(
+					'file' => $file,
+				)
+			);
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Parse a JSON string into an object, and handle parsing errors.
+	 *
+	 * @param string $content
+	 *
+	 * @return object|WP_Error
+	 */
+	protected static function parse_content( $content ) {
+		$parsed = json_decode( $content );
+		$error  = json_last_error_msg();
+
+		// TODO Once we are on PHP 7.3 we can use the JSON_THROW_ON_ERROR option and catch an exception here.
+		if ( 'No error' !== $error ) {
+			return new WP_Error(
+				'json_parse_error',
+				esc_html( $error ),
+				array(
+					'error_code' => json_last_error(),
+				)
+			);
+		}
+
+		return $parsed;
+	}
+}

--- a/block-json/class-parser.php
+++ b/block-json/class-parser.php
@@ -159,7 +159,10 @@ class Parser {
 		if ( 'No error' !== $error ) {
 			return new WP_Error(
 				'json_parse_error',
-				esc_html( $error ),
+				sprintf(
+					__( 'JSON Parser: %s', 'wporg-plugins' ),
+					esc_html( $error )
+				),
 				array(
 					'error_code' => json_last_error(),
 				)

--- a/block-json/class-validator.php
+++ b/block-json/class-validator.php
@@ -177,7 +177,7 @@ class Validator {
 					'type' => 'string',
 				),
 			),
-			'required'             => array( 'name', 'title', 'category' ),
+			'required'             => array( 'name', 'title' ),
 			'additionalProperties' => false,
 		);
 	}

--- a/block-json/class-validator.php
+++ b/block-json/class-validator.php
@@ -362,14 +362,16 @@ class Validator {
 
 		if ( isset( $schema['items']['type'] ) ) {
 			$results = array();
+			$index   = 0;
 
 			foreach ( $array as $item ) {
 				$results[] = $this->route_validation_for_type(
 					$schema['items']['type'],
 					$item,
-					$prop . '[]',
+					$prop . "[$index]",
 					$schema['items']
 				);
+				$index ++;
 			}
 
 			return ! in_array( false, $results, true );

--- a/block-json/class-validator.php
+++ b/block-json/class-validator.php
@@ -78,10 +78,12 @@ class Validator {
 					'type' => 'string',
 				),
 				'editorScript' => array(
-					'type' => 'string',
+					'type'    => 'string',
+					'pattern' => '\.js$',
 				),
 				'editorStyle'  => array(
-					'type' => 'string',
+					'type'    => 'string',
+					'pattern' => '\.css$',
 				),
 				'example'      => array(
 					'type'                 => 'object',
@@ -108,10 +110,12 @@ class Validator {
 					),
 				),
 				'script'       => array(
-					'type' => 'string',
+					'type'    => 'string',
+					'pattern' => '\.js$',
 				),
 				'style'        => array(
-					'type' => 'string',
+					'type'    => 'string',
+					'pattern' => '\.css$',
 				),
 				'styles'       => array(
 					'type'  => 'array',
@@ -411,6 +415,26 @@ class Validator {
 			}
 		}
 
+		if ( isset( $schema['pattern'] ) ) {
+			if ( ! preg_match( '#' . $schema['pattern'] . '#', $string ) ) {
+				$pattern_description = $this->get_human_readable_pattern_description( $schema['pattern'] );
+				if ( $pattern_description ) {
+					$message = sprintf(
+						$pattern_description,
+						'<code>' . $prop . '</code>'
+					);
+				} else {
+					$message = sprintf(
+						__( 'The value of %s does not match the required pattern.', 'wporg-plugins' ),
+						'<code>' . $prop . '</code>'
+					);
+				}
+
+				$this->messages->add( 'warning', $message );
+				$this->append_error_data( $prop, 'warning' );
+			}
+		}
+
 		return true;
 	}
 
@@ -502,5 +526,27 @@ class Validator {
 		$data   = $this->messages->get_error_data( $error_code ) ?: array();
 		$data[] = $new_data;
 		$this->messages->add_data( $data, $error_code );
+	}
+
+	/**
+	 * Get a description of a regex pattern that can be understood by humans.
+	 *
+	 * @param string $pattern A regex pattern.
+	 *
+	 * @return string
+	 */
+	protected function get_human_readable_pattern_description( $pattern ) {
+		$description = '';
+
+		switch ( $pattern ) {
+			case '\.css$':
+				$description = __( 'The value of %s must end in ".css".', 'wporg-plugins' );
+				break;
+			case '\.js$':
+				$description = __( 'The value of %s must end in ".js".', 'wporg-plugins' );
+				break;
+		}
+
+		return $description;
 	}
 }

--- a/block-json/class-validator.php
+++ b/block-json/class-validator.php
@@ -314,6 +314,7 @@ class Validator {
 							)
 						);
 						$this->append_error_data( "$prop:$key", 'warning' );
+						$results[] = false;
 						continue;
 					}
 				}

--- a/block-json/class-validator.php
+++ b/block-json/class-validator.php
@@ -1,0 +1,497 @@
+<?php
+
+namespace WordPressdotorg\Plugin_Directory\Block_JSON;
+
+use WP_Error;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Validator
+ *
+ * @package WordPressdotorg\Plugin_Directory\Block_JSON
+ */
+class Validator {
+	/**
+	 * @var WP_Error
+	 */
+	protected $messages;
+
+	/**
+	 * Validator constructor.
+	 */
+	public function __construct() {
+		$this->messages = new WP_Error();
+	}
+
+	/**
+	 * The schema for the block.json file.
+	 *
+	 * This attempts to follow the schema for the schema.
+	 * See https://json-schema.org/understanding-json-schema/reference/index.html
+	 *
+	 * @return array
+	 */
+	public static function schema() {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'attributes'   => array(
+					'type'                 => 'object',
+					'additionalProperties' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'attribute' => array(
+								'type' => 'string',
+							),
+							'meta'      => array(
+								'type' => 'string',
+							),
+							'multiline' => array(
+								'type' => 'string',
+							),
+							'query'     => array(
+								'type' => 'object',
+							),
+							'selector'  => array(
+								'type' => 'string',
+							),
+							'source'    => array(
+								'type' => 'string',
+								'enum' => array( 'attribute', 'text', 'html', 'query' ),
+							),
+							'type'      => array(
+								'type' => 'string',
+								'enum' => array( 'null', 'boolean', 'object', 'array', 'number', 'string', 'integer' ),
+							),
+						),
+						'required'   => array( 'type' ),
+					),
+				),
+				'category'     => array(
+					'type' => 'string',
+				),
+				'description'  => array(
+					'type' => 'string',
+				),
+				'editorScript' => array(
+					'type' => 'string',
+				),
+				'editorStyle'  => array(
+					'type' => 'string',
+				),
+				'example'      => array(
+					'type'                 => 'object',
+					'additionalProperties' => array(
+						'type' => 'object',
+					),
+				),
+				'icon'         => array(
+					'type' => 'string',
+				),
+				'keywords'     => array(
+					'type'  => 'array',
+					'items' => array(
+						'type' => 'string',
+					),
+				),
+				'name'         => array(
+					'type' => 'string',
+				),
+				'parent'       => array(
+					'type'  => 'array',
+					'items' => array(
+						'type' => 'string',
+					),
+				),
+				'script'       => array(
+					'type' => 'string',
+				),
+				'style'        => array(
+					'type' => 'string',
+				),
+				'styles'       => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'isDefault' => array(
+								'type' => 'boolean',
+							),
+							'label'     => array(
+								'type' => 'string',
+							),
+							'name'      => array(
+								'type' => 'string',
+							),
+						),
+					),
+				),
+				'supports'     => array(
+					'type'       => 'object',
+					'properties' => array(
+						'align'           => array(
+							'type'  => array( 'boolean', 'array' ),
+							'items' => array(
+								'type' => 'string',
+								'enum' => array( 'left', 'center', 'right', 'wide', 'full' ),
+							),
+						),
+						'alignWide'       => array(
+							'type' => 'boolean',
+						),
+						'anchor'          => array(
+							'type' => 'boolean',
+						),
+						'className'       => array(
+							'type' => 'boolean',
+						),
+						'customClassName' => array(
+							'type' => 'boolean',
+						),
+						'html'            => array(
+							'type' => 'boolean',
+						),
+						'inserter'        => array(
+							'type' => 'boolean',
+						),
+						'multiple'        => array(
+							'type' => 'boolean',
+						),
+						'reusable'        => array(
+							'type' => 'boolean',
+						),
+					),
+				),
+				'textdomain'   => array(
+					'type' => 'string',
+				),
+				'title'        => array(
+					'type' => 'string',
+				),
+			),
+			'required'             => array( 'name', 'title', 'category' ),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Validate a PHP object representation of a block.json file.
+	 *
+	 * @param object $block_json
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function validate( $block_json ) {
+		$schema = self::schema();
+
+		$this->validate_object( $block_json, 'block.json', $schema );
+		$this->check_conditional_properties( $block_json );
+
+		if ( $this->messages->has_errors() ) {
+			return $this->messages;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check for properties that are conditionally required.
+	 *
+	 * @param object $block_json
+	 *
+	 * @return void
+	 */
+	protected function check_conditional_properties( $block_json ) {
+		if ( ! is_object( $block_json ) ) {
+			return;
+		}
+
+		if ( ! isset( $block_json->script ) && ! isset( $block_json->editorScript ) ) {
+			$this->messages->add(
+				'error',
+				sprintf(
+					__( 'At least one of the following properties must be present: %s', 'wporg-plugins' ),
+					// translators: used between list items, there is a space after the comma.
+					'<code>script</code>' . __( ', ', 'wporg-plugins' ) . '<code>editorScript</code>'
+				)
+			);
+			$this->append_error_data( 'block.json:script', 'error' );
+			$this->append_error_data( 'block.json:editorScript', 'error' );
+		}
+
+		if ( ! isset( $block_json->style ) && ! isset( $block_json->editorStyle ) ) {
+			$this->messages->add(
+				'error',
+				sprintf(
+					__( 'At least one of the following properties must be present: %s', 'wporg-plugins' ),
+					// translators: used between list items, there is a space after the comma.
+					'<code>style</code>' . __( ', ', 'wporg-plugins' ) . '<code>editorStyle</code>'
+				)
+			);
+			$this->append_error_data( 'block.json:style', 'error' );
+			$this->append_error_data( 'block.json:editorStyle', 'error' );
+		}
+	}
+
+	/**
+	 * Validate an object and its properties.
+	 *
+	 * @param object $object The value to validate as an object.
+	 * @param string $prop   The name of the property, used in error reporting.
+	 * @param array  $schema The schema for the property, used for validation.
+	 *
+	 * @return bool
+	 */
+	protected function validate_object( $object, $prop, $schema ) {
+		if ( ! is_object( $object ) ) {
+			$this->messages->add(
+				'error',
+				sprintf(
+					__( 'The %s property must contain an object value.', 'wporg-plugins' ),
+					'<code>' . $prop . '</code>'
+				)
+			);
+			$this->append_error_data( $prop, 'error' );
+
+			return false;
+		}
+
+		$results = array();
+
+		if ( isset( $schema['required'] ) ) {
+			foreach ( $schema['required'] as $required_prop ) {
+				if ( ! property_exists( $object, $required_prop ) ) {
+					$this->messages->add(
+						'error',
+						sprintf(
+							__( 'The %1$s property is required in the %2$s object.', 'wporg-plugins' ),
+							'<code>' . $required_prop . '</code>',
+							'<code>' . $prop . '</code>'
+						)
+					);
+					$this->append_error_data( "$prop:$required_prop", 'error' );
+					$results[] = false;
+				}
+			}
+		}
+
+		if ( isset( $schema['properties'] ) ) {
+			foreach ( $schema['properties'] as $subprop => $subschema ) {
+				if ( ! isset( $object->$subprop ) ) {
+					continue;
+				}
+
+				if ( isset( $subschema['type'] ) ) {
+					$results[] = $this->route_validation_for_type(
+						$subschema['type'],
+						$object->$subprop,
+						"$prop:$subprop",
+						$subschema
+					);
+				}
+			}
+		}
+
+		if ( isset( $schema['additionalProperties'] ) ) {
+			if ( false === $schema['additionalProperties'] ) {
+				foreach ( get_object_vars( $object ) as $var ) {
+					if ( ! isset( $schema[ $var ] ) ) {
+						$this->messages->add(
+							'warning',
+							sprintf(
+								__( '%1$s is not a valid property in the %2$s object.', 'wporg-plugins' ),
+								'<code>' . $var . '</code>',
+								'<code>' . $prop . '</code>'
+							)
+						);
+						$this->append_error_data( "$prop:$var", 'warning' );
+						continue;
+					}
+				}
+			} elseif ( isset( $schema['additionalProperties']['type'] ) ) {
+				foreach ( $object as $subprop => $subvalue ) {
+					$results[] = $this->route_validation_for_type(
+						$schema['additionalProperties']['type'],
+						$subvalue,
+						"$prop:$subprop",
+						$schema['additionalProperties']
+					);
+				}
+			}
+		}
+
+		return ! in_array( false, $results, true );
+	}
+
+	/**
+	 * Validate an array and its items.
+	 *
+	 * @param array  $array  The value to validate as an array.
+	 * @param string $prop   The name of the property, used in error reporting.
+	 * @param array  $schema The schema for the property, used for validation.
+	 *
+	 * @return bool
+	 */
+	protected function validate_array( $array, $prop, $schema ) {
+		if ( ! is_array( $array ) ) {
+			$this->messages->add(
+				'error',
+				sprintf(
+					__( 'The %s property must contain an array value.', 'wporg-plugins' ),
+					'<code>' . $prop . '</code>'
+				)
+			);
+			$this->append_error_data( $prop, 'error' );
+
+			return false;
+		}
+
+		if ( isset( $schema['items']['type'] ) ) {
+			$results = array();
+
+			foreach ( $array as $item ) {
+				$results[] = $this->route_validation_for_type(
+					$schema['items']['type'],
+					$item,
+					$prop . '[]',
+					$schema['items']
+				);
+			}
+
+			return ! in_array( false, $results, true );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate a string.
+	 *
+	 * @param string $string The value to validate as a string.
+	 * @param string $prop   The name of the property, used in error reporting.
+	 * @param array  $schema The schema for the property, used for validation.
+	 *
+	 * @return bool
+	 */
+	protected function validate_string( $string, $prop, $schema ) {
+		if ( ! is_string( $string ) ) {
+			$this->messages->add(
+				'error',
+				sprintf(
+					__( 'The %s property must contain a string value.', 'wporg-plugins' ),
+					'<code>' . $prop . '</code>'
+				)
+			);
+			$this->append_error_data( $prop, 'error' );
+
+			return false;
+		}
+
+		if ( isset( $schema['enum'] ) ) {
+			if ( ! in_array( $string, $schema['enum'], true ) ) {
+				$this->messages->add(
+					'warning',
+					sprintf(
+						__( '"%1$s" is not a valid value for the %2$s property.', 'wporg-plugins' ),
+						esc_html( $string ),
+						'<code>' . $prop . '</code>'
+					)
+				);
+				$this->append_error_data( $prop, 'warning' );
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate a boolean.
+	 *
+	 * @param bool   $boolean The value to validate as a boolean.
+	 * @param string $prop    The name of the property, used in error reporting.
+	 *
+	 * @return bool
+	 */
+	protected function validate_boolean( $boolean, $prop ) {
+		if ( ! is_bool( $boolean ) ) {
+			$this->messages->add(
+				'error',
+				sprintf(
+					__( 'The %s property must contain a boolean value.', 'wporg-plugins' ),
+					'<code>' . $prop . '</code>'
+				)
+			);
+			$this->append_error_data( $prop, 'error' );
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Send a property value to the correct validator depending on which type(s) it can be.
+	 *
+	 * @param string|array $valid_types
+	 * @param mixed        $value
+	 * @param string       $prop
+	 * @param array        $schema
+	 *
+	 * @return bool
+	 */
+	protected function route_validation_for_type( $valid_types, $value, $prop, $schema ) {
+		// There is a single valid type.
+		if ( is_string( $valid_types ) ) {
+			$method = "validate_$valid_types";
+			return $method( $value, $prop, $schema );
+		}
+
+		// There are multiple valid types in an array.
+		foreach ( $valid_types as $type ) {
+			switch ( $type ) {
+				case 'boolean':
+					$check = 'is_bool';
+					break;
+				default:
+					$check = "is_$type";
+					break;
+			}
+
+			if ( $check( $value ) ) {
+				$method = "validate_$type";
+				return $method( $value, $prop, $schema );
+			}
+		}
+
+		// Made it this far, it's none of the valid types.
+		$this->messages->add(
+			'error',
+			sprintf(
+				__( 'The %1$s property must contain a value that is one of these types: %2$s', 'wporg-plugins' ),
+				'<code>' . $prop . '</code>',
+				// translators: used between list items, there is a space after the comma.
+				'<code>' . implode( '</code>' . __( ', ', 'wporg-plugins' ) . '<code>', $valid_types ) . '</code>'
+			)
+		);
+		$this->append_error_data( $prop, 'error' );
+
+		return false;
+	}
+
+	/**
+	 * Add more data to an error code.
+	 *
+	 * The `add_data` method in WP_Error replaces data with each subsequent call with the same error code.
+	 *
+	 * @param mixed  $new_data   The data to append.
+	 * @param string $error_code The error code to assign the data to.
+	 *
+	 * @return void
+	 */
+	protected function append_error_data( $new_data, $error_code ) {
+		$data   = $this->messages->get_error_data( $error_code ) ?: array();
+		$data[] = $new_data;
+		$this->messages->add_data( $data, $error_code );
+	}
+}

--- a/class-plugin-directory.php
+++ b/class-plugin-directory.php
@@ -575,6 +575,7 @@ class Plugin_Directory {
 		add_shortcode( 'wporg-plugins-screenshots', array( __NAMESPACE__ . '\Shortcodes\Screenshots', 'display' ) );
 		add_shortcode( 'wporg-plugins-reviews', array( __NAMESPACE__ . '\Shortcodes\Reviews', 'display' ) );
 		add_shortcode( 'readme-validator', array( __NAMESPACE__ . '\Shortcodes\Readme_Validator', 'display' ) );
+		add_shortcode( 'block-validator', array( __NAMESPACE__ . '\Shortcodes\Block_Validator', 'display' ) );
 	}
 
 	/**
@@ -590,6 +591,7 @@ class Plugin_Directory {
 			'wporg-plugins-screenshots',
 			'wporg-plugins-reviews',
 			'readme-validator',
+			'block-validator',
 		);
 
 		$not_allowed_shortcodes = array_diff( array_keys( $shortcode_tags ), $allowed_shortcodes );

--- a/cli/class-block-plugin-checker.php
+++ b/cli/class-block-plugin-checker.php
@@ -1,0 +1,293 @@
+<?php
+namespace WordPressdotorg\Plugin_Directory\CLI;
+
+use WordPressdotorg\Plugin_Directory\Readme\Parser;
+use WordPressdotorg\Plugin_Directory\Tools\Filesystem;
+
+/**
+ * A class that can examine a plugin, and evaluate and return status info that would be useful for a validator or similar tool.
+ *
+ * Note: I've written this as one class for convenience, but as it's evolved I think it would make sense to split it in two: one for collecting data
+ * (particularly the prepare*() and find*() functions), and a separate class for the checks.
+ *
+ * @package WordPressdotorg\Plugin_Directory\CLI
+ */
+class Block_Plugin_Checker {
+
+	protected $path_to_plugin = null;
+	protected $check_methods = array();
+	protected $results = array();
+
+	protected $slug = null;
+	protected $readme_path = null;
+	protected $readme = null;
+	protected $headers = null;
+	protected $blocks = null;
+	protected $block_json_files = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $slug The plugin slug, if known. Optional.
+	 */
+	public function __construct( $slug = null ) {
+		$this->slug = $slug;
+	}
+
+	/**
+	 * Check a plugin that has been unzipped or exported to a local filesystem.
+	 *
+	 * @param string $path_to_plugin Location where the plugin has been stored.
+	 * @return array A list of status items.
+	 */
+	public function run_check_plugin_files( $path_to_plugin ) {
+		$this->path_to_plugin = $path_to_plugin;
+		$this->init();
+		$this->prepare_data();
+		$this->run_all_checks();
+		return $this->results;
+	}
+
+	protected function init() {
+
+		// Find all the methods on this class starting with `check_`
+		$methods = get_class_methods( $this );
+		foreach ( $methods as $method ) {
+			if ( 0 === strpos( $method, 'check_' ) )
+				$this->check_methods[] = $method;
+		}
+	}
+
+	protected function prepare_data() {
+		// Parse and stash the readme data
+		$this->readme_path = Import::find_readme_file( $this->path_to_plugin );
+		$this->readme = new Parser( $this->readme_path );
+
+		// Parse and stash plugin headers
+		$this->headers = Import::find_plugin_headers( $this->path_to_plugin );
+
+		// Parse and stash block info
+		$this->blocks = $this->find_blocks( $this->path_to_plugin );
+	}
+
+	public function run_all_checks() {
+		foreach ( array_unique( $this->check_methods ) as $method ) {
+			call_user_func( array( $this, $method ) );
+		}
+	}
+
+	public function find_blocks( $base_dir ) {
+		$block_json_files = Filesystem::list_files( $base_dir, true, '!(?:^|/)block\.json$!i' );
+		if ( ! empty( $block_json_files ) ) {
+			foreach ( $block_json_files as $filename ) {
+				$blocks_in_file = Import::find_blocks_in_file( $filename );
+				$relative_filename = str_replace( "$base_dir/", '', $filename );
+				$potential_block_directories[] = dirname( $relative_filename );
+				foreach ( $blocks_in_file as $block ) {
+					$blocks[ $block->name ] = $block;
+					$this->block_json_files[ $block->name ] = $filename;
+				}
+			}
+		} else {
+			foreach ( Filesystem::list_files( $base_dir, true, '!\.(?:php|js|jsx)$!i' ) as $filename ) {
+				$blocks_in_file = Import::find_blocks_in_file( $filename );
+				if ( ! empty( $blocks_in_file ) ) {
+					$relative_filename = str_replace( "$base_dir/", '', $filename );
+					$potential_block_directories[] = dirname( $relative_filename );
+					foreach ( $blocks_in_file as $block ) {
+						if ( preg_match( '!\.(?:js|jsx)$!i', $relative_filename ) && empty( $block->script ) )
+							$block->script = $relative_filename;
+						$blocks[ $block->name ] = $block;
+					}
+				}
+			}
+		}
+
+		return $blocks;
+	}
+
+	public function find_block_scripts() {
+		$block_scripts = array();
+		foreach ( $this->blocks as $block ) {
+			$scripts = Import::extract_file_paths_from_block_json( $block );
+			if ( isset( $block_scripts[ $block->name ] ) ) {
+				$block_scripts[ $block->name ] = array_merge( $block_scripts[ $block->name ], $scripts );
+			} else {
+				$block_scripts[ $block->name ] = $scripts;
+			}
+		}
+
+		return $block_scripts;
+	}
+
+	/**
+	 * Used by check_*() functions to record info.
+	 *
+	 * @param string $check_name An unambiguous name of the check. Should normally be the calling __FUNCTION__.
+	 * @param string $type The type of info being recorded: 'error', 'problem', 'info', etc.
+	 * @param string $message A human-readable message explaining the info.
+	 * @param mixed $data Additional data related to the info, optional. Typically a string or array.
+	 */
+	protected function record_result( $check_name, $type, $message, $data = null ) {
+		$this->results[] = (object) array(
+			'check_name' => $check_name,
+			'type' => $type,
+			'message' => $message, 
+			'data' => $data );
+	}
+
+	/**
+	 * Check functions below here. Must be named `check_*()`.
+	 */
+
+	/**
+	 * Readme.txt file must be present.
+	 */
+	function check_readme_exists() {
+		if ( !file_exists( $this->path_to_plugin . '/readme.txt' ) ) {
+			$this->record_result( __FUNCTION__,
+				'error',
+				__( 'Missing readme.txt file' )
+			);
+		}
+	}
+
+	/**
+	 * Readme should have a license.
+	 */
+	function check_license() {
+		if ( empty( $this->readme->license ) ) {
+			$this->record_result( __FUNCTION__,
+				'problem',
+				__( 'Missing license in readme.txt.' )
+			);
+		} else {
+			$this->record_result( __FUNCTION__,
+				'info',
+				__( 'Found a license in readme.txt.' ),
+				$this->readme->license
+			);
+		}
+	}
+
+	/**
+	 * Does the plugin have a block name that already exists in the DB?
+	 * Note that this isn't a blocker if we're re-running checks on a plugin that has already been uploaded, since it will match with itself.
+	 */
+	function check_for_duplicate_block_name() {
+		foreach ( $this->blocks as $block ) {
+			if ( !trim( strval( $block->name ) ) )
+				continue;
+
+			$query_args = array(
+				'post_type' => 'plugin',
+				'meta_query' => array(
+					array(
+						'key' => 'block_name',
+						'value' => $block->name,
+					)
+				)
+			);
+
+			$query = new \WP_Query( $query_args );
+			if ( $query->found_posts > 0 ) {
+				foreach ( $query->posts as $post ) {
+					if ( $this->slug && $this->slug === $post->post_name )
+						continue; // It's this very same plugin
+
+					$this->record_result( __FUNCTION__, 
+						'info', 
+						sprintf( __( 'Block name already exists in plugin %s' ), $query->posts[0]->post_name ), 
+						[ 'block_name' => $block->name, 'slug' => $post->post_name ]
+					);
+				}
+			}
+		}
+
+	}
+
+	/**
+	 * There should be at least one block.
+	 */
+	function check_for_blocks() {
+		if ( 0 === count( $this->blocks ) ) {
+			$this->record_result( __FUNCTION__,
+				'problem',
+				__( 'No blocks found in plugin.' )
+			);
+		} else {
+			$this->record_result( __FUNCTION__,
+				'info',
+				sprintf( __( 'Found %d blocks' ), count( $this->blocks ) ),
+				array_keys( $this->blocks )
+			);
+		}
+	}
+
+	/**
+	 * Every block should have a block.json file, ideally.
+	 */
+	function check_for_block_json() {
+		foreach ( $this->blocks as $block_name => $block_info ) {
+			if ( !empty( $this->block_json_files[ $block_name ] ) ) {
+				$this->record_result( __FUNCTION__,
+					'info',
+					sprintf( __( 'block.json file exists for block %s' ), $block_name ),
+					$this->block_json_files[ $block_name ]
+				);
+			} else {
+				$this->record_result( __FUNCTION__,
+					'problem',
+					sprintf( __( 'Missing block.json file for block %s' ), $block_name ),
+					$block_name
+				);
+			}
+		}
+	}
+
+	/**
+	 * Do the blocks all have available script assets, either discoverable or in the block.json file?
+	 */
+	function check_for_block_scripts() {
+		$block_scripts = $this->find_block_scripts();
+
+		foreach ( $this->blocks as $block_name => $block_info ) {
+			if ( !empty( $block_scripts[ $block_name ] ) ) {
+				$this->record_result( __FUNCTION__,
+					'info',
+					sprintf( __( 'Scripts found for block %s' ), $block_name ),
+					$block_scripts[ $block_name ]
+				);
+			} else {
+				$this->record_result( __FUNCTION__,
+					'problem',
+					sprintf( __( 'No scripts found for block %s' ), $block_name ),
+					$block_name
+				);
+			}
+		}
+	}
+
+	/**
+	 * Do the script files all exist?
+	 */
+	function check_for_block_script_files() {
+		foreach ( $this->find_block_scripts() as $block_name => $scripts ) {
+			foreach ( $scripts as $script ) {
+				if ( file_exists( $this->path_to_plugin . $script ) ) {
+					$this->record_result( __FUNCTION__,
+						'info',
+						sprintf( __( 'Script file exists for block %s' ), $block_name ),
+						$script
+					);
+				} else {
+					$this->record_result( __FUNCTION__,
+						'problem',
+						sprintf( __( 'Missing script file for block %s' ), $block_name ),
+						$script
+					);
+				}
+			}
+		}
+	}
+}

--- a/cli/class-block-plugin-checker.php
+++ b/cli/class-block-plugin-checker.php
@@ -56,7 +56,7 @@ class Block_Plugin_Checker {
 
 		// git@github.com:sortabrilliant/jumbotron.git
 
-		if ( preg_match( '#^\w+@github[.]com:(\w+/[^.]+)\.git$#', $url, $matches ) ) {
+		if ( preg_match( '#^\w+@github[.]com:(\w+/[^.]+)(?:\.git)?$#', $url, $matches ) ) {
 			$url = 'https://github.com/' . $matches[1];
 		}
 
@@ -109,7 +109,7 @@ class Block_Plugin_Checker {
 			// git@github.com:sortabrilliant/jumbotron.git
 			// https://github.com/sortabrilliant/jumbotron.git
 			//
-			if ( preg_match( '#^/(\w+/[^.]+)\.git#', $url_parts[ 'path' ], $matches ) ) {
+			if ( preg_match( '#^/(\w+/[^.]+)(?:\.git)?$#', $url_parts[ 'path' ], $matches ) ) {
 				$url = 'https://github.com/' . $matches[1] . '.git/trunk';
 			} else {
 				$this->record_result(

--- a/cli/class-block-plugin-checker.php
+++ b/cli/class-block-plugin-checker.php
@@ -194,8 +194,6 @@ class Block_Plugin_Checker {
 		// Parse and stash block info
 		$this->blocks = $this->find_blocks( $this->path_to_plugin );
 
-		$this->block_json_files = Filesystem::list_files( $this->path_to_plugin, true, '!(?:^|/)block\.json$!i' );
-
 		foreach ( $this->block_json_files as $block_json_file ) {
 			$validator = new Block_JSON_Validator();
 			$block_json = Block_JSON_Parser::parse( array( 'file' => $block_json_file ) );
@@ -214,15 +212,14 @@ class Block_Plugin_Checker {
 	}
 
 	public function find_blocks( $base_dir ) {
-		$block_json_files = Filesystem::list_files( $base_dir, true, '!(?:^|/)block\.json$!i' );
-		if ( false && ! empty( $block_json_files ) ) {
+		$this->block_json_files = Filesystem::list_files( $base_dir, true, '!(?:^|/)block\.json$!i' );
+		if ( false && ! empty( $this->block_json_files ) ) {
 			foreach ( $block_json_files as $filename ) {
 				$blocks_in_file = Import::find_blocks_in_file( $filename );
 				$relative_filename = $this->relative_filename( $filename );
 				$potential_block_directories[] = dirname( $relative_filename );
 				foreach ( $blocks_in_file as $block ) {
 					$blocks[ $block->name ] = $block;
-					$this->block_json_files[ $block->name ] = $filename;
 				}
 			}
 		} else {

--- a/cli/class-block-plugin-checker.php
+++ b/cli/class-block-plugin-checker.php
@@ -433,6 +433,28 @@ class Block_Plugin_Checker {
 	}
 
 	/**
+	 * Does the JS call registerBlockType?
+	 */
+	function check_for_register_block_type() {
+		$block_files = array();
+		foreach ( Filesystem::list_files( $this->path_to_plugin, true, '!\.(?:js|jsx)$!i' ) as $filename ) {
+			$js = file_get_contents( $filename );
+			// TODO: need something better than this. find_blocks_in_file() misses quite a few unfortunately.
+			if ( false !== strpos( $js, 'registerBlockType' ) ) {
+				$block_files[] = $filename;
+			}
+			unset( $js );
+		}
+
+		if ( empty( $block_files ) ) {
+			$this->record_result( __FUNCTION__,
+				'error',
+				sprintf( __( 'registerBlockType() must be called in a JavaScript file' ) )
+			);
+		}
+	}
+
+	/**
 	 * Are the block.json files parseable?
 	 */
 	function check_block_json_is_valid_json() {

--- a/cli/class-block-plugin-checker.php
+++ b/cli/class-block-plugin-checker.php
@@ -150,7 +150,7 @@ class Block_Plugin_Checker {
 		if ( file_exists( $path ) )
 			return false;
 
-		$export = SVN::export( $svn_url, $path, array( '-rHEAD' ) );
+		$export = SVN::export( $svn_url, $path, array( 'ignore-externals' ) );
 		if ( $export['result'] ) {
 			$this->repo_revision = $export['revision'];
 			$this->repo_url = $svn_url;

--- a/cli/class-block-plugin-checker.php
+++ b/cli/class-block-plugin-checker.php
@@ -67,7 +67,7 @@ class Block_Plugin_Checker {
 			$this->record_result(
 				__FUNCTION__,
 				'error',
-				sprintf( __( 'Invalid url %s' ), $url ),
+				sprintf( __( 'Invalid url %s', 'wporg-plugins' ), $url ),
 				$url
 			);
 			return $this->results;
@@ -77,7 +77,7 @@ class Block_Plugin_Checker {
 			$this->record_result(
 				__FUNCTION__,
 				'error',
-				sprintf( __( 'URL must be GitHub or plugins.svn.wordpress.org %s' ), $url ),
+				sprintf( __( 'URL must be GitHub or plugins.svn.wordpress.org %s', 'wporg-plugins' ), $url ),
 				$url
 			);
 			return $this->results;
@@ -89,7 +89,7 @@ class Block_Plugin_Checker {
 				$this->record_result(
 					__FUNCTION__,
 					'error',
-					sprintf( __( 'URL must be a plugin repository %s' ), $url ),
+					sprintf( __( 'URL must be a plugin repository %s', 'wporg-plugins' ), $url ),
 					$url
 				);
 				return $this->results;
@@ -115,7 +115,7 @@ class Block_Plugin_Checker {
 				$this->record_result(
 					__FUNCTION__,
 					'error',
-					sprintf( __( 'URL must be a plugin repository %s' ), $url ),
+					sprintf( __( 'URL must be a plugin repository %s', 'wporg-plugins' ), $url ),
 					$url
 				);
 				return $this->results;
@@ -151,7 +151,7 @@ class Block_Plugin_Checker {
 			$this->record_result(
 				__FUNCTION__,
 				'error',
-				sprintf( __( 'Error fetching repository %s: %s' ), $svn_url, $export['errors'][0]['error_code'] ),
+				sprintf( __( 'Error fetching repository %s: %s', 'wporg-plugins' ), $svn_url, $export['errors'][0]['error_code'] ),
 				$export['errors']
 			);
 			return false;
@@ -284,7 +284,7 @@ class Block_Plugin_Checker {
 		if ( empty( $this->readme_path ) || !file_exists( $this->readme_path ) ) {
 			$this->record_result( __FUNCTION__,
 				'error',
-				__( 'Missing readme.txt file' ),
+				__( 'Missing readme.txt file', 'wporg-plugins' ),
 				$this->relative_filename( $this->readme_path )
 			);
 		}
@@ -297,12 +297,12 @@ class Block_Plugin_Checker {
 		if ( empty( $this->readme->license ) ) {
 			$this->record_result( __FUNCTION__,
 				'warning',
-				__( 'Missing license in readme.txt.' )
+				__( 'Missing license in readme.txt.', 'wporg-plugins' )
 			);
 		} else {
 			$this->record_result( __FUNCTION__,
 				'info',
-				__( 'Found a license in readme.txt.' ),
+				__( 'Found a license in readme.txt.', 'wporg-plugins' ),
 				$this->readme->license
 			);
 		}
@@ -335,7 +335,7 @@ class Block_Plugin_Checker {
 
 					$this->record_result( __FUNCTION__, 
 						'info', 
-						sprintf( __( 'Block name already exists in plugin %s' ), $query->posts[0]->post_name ), 
+						sprintf( __( 'Block name already exists in plugin %s', 'wporg-plugins' ), $query->posts[0]->post_name ), 
 						[ 'block_name' => $block->name, 'slug' => $post->post_name ]
 					);
 				}
@@ -351,12 +351,12 @@ class Block_Plugin_Checker {
 		if ( 0 === count( $this->blocks ) ) {
 			$this->record_result( __FUNCTION__,
 				'error',
-				__( 'No blocks found in plugin.' )
+				__( 'No blocks found in plugin.', 'wporg-plugins' )
 			);
 		} else {
 			$this->record_result( __FUNCTION__,
 				'info',
-				sprintf( __( 'Found %d blocks' ), count( $this->blocks ) ),
+				sprintf( _n( 'Found %d block', 'Found %d blocks', count( $this->blocks ), 'wporg-plugins' ), count( $this->blocks ) ),
 				array_keys( $this->blocks )
 			);
 		}
@@ -370,7 +370,7 @@ class Block_Plugin_Checker {
 			if ( !empty( $this->block_json_files[ $block_name ] ) ) {
 				$this->record_result( __FUNCTION__,
 					'info',
-					sprintf( __( 'block.json file exists for block %s' ), $block_name ),
+					sprintf( __( 'block.json file exists for block %s', 'wporg-plugins' ), $block_name ),
 					$this->block_json_files[ $block_name ]
 				);
 			}
@@ -379,7 +379,7 @@ class Block_Plugin_Checker {
 		if ( empty( $this->block_json_files ) ) {
 			$this->record_result( __FUNCTION__,
 				'warning',
-				__( 'No block.json files were found' )
+				__( 'No block.json files were found', 'wporg-plugins' )
 			);
 		}
 	}
@@ -394,13 +394,13 @@ class Block_Plugin_Checker {
 			if ( !empty( $block_scripts[ $block_name ] ) ) {
 				$this->record_result( __FUNCTION__,
 					'info',
-					sprintf( __( 'Scripts found for block %s' ), $block_name ),
+					sprintf( __( 'Scripts found for block %s', 'wporg-plugins' ), $block_name ),
 					$block_scripts[ $block_name ]
 				);
 			} else {
 				$this->record_result( __FUNCTION__,
 					'warning',
-					sprintf( __( 'No scripts found for block %s' ), $block_name ),
+					sprintf( __( 'No scripts found for block %s', 'wporg-plugins' ), $block_name ),
 					$block_name
 				);
 			}
@@ -416,13 +416,13 @@ class Block_Plugin_Checker {
 				if ( file_exists( $this->path_to_plugin . $script ) ) {
 					$this->record_result( __FUNCTION__,
 						'info',
-						sprintf( __( 'Script file exists for block %s' ), $block_name ),
+						sprintf( __( 'Script file exists for block %s', 'wporg-plugins' ), $block_name ),
 						$script
 					);
 				} else {
 					$this->record_result( __FUNCTION__,
 						'warning',
-						sprintf( __( 'Missing script file for block %s' ), $block_name ),
+						sprintf( __( 'Missing script file for block %s', 'wporg-plugins' ), $block_name ),
 						$script
 					);
 				}
@@ -447,7 +447,7 @@ class Block_Plugin_Checker {
 		if ( empty( $block_files ) ) {
 			$this->record_result( __FUNCTION__,
 				'error',
-				sprintf( __( 'registerBlockType() must be called in a JavaScript file' ) )
+				sprintf( __( 'registerBlockType() must be called in a JavaScript file', 'wporg-plugins' ) )
 			);
 		}
 	}
@@ -461,7 +461,7 @@ class Block_Plugin_Checker {
 				if ( $message = $result->get_error_message( 'json_parse_error' ) ) {
 					$this->record_result( __FUNCTION__,
 						'error',
-						sprintf( __( 'Error attempting to parse json in %s: %s' ), $this->relative_filename( $block_json_file ), $message ),
+						sprintf( __( 'Error attempting to parse json in %s: %s', 'wporg-plugins' ), $this->relative_filename( $block_json_file ), $message ),
 						$this->relative_filename( $block_json_file )
 					);
 				}

--- a/cli/class-block-plugin-checker.php
+++ b/cli/class-block-plugin-checker.php
@@ -34,7 +34,7 @@ class Block_Plugin_Checker {
 	protected $headers = null;
 	protected $blocks = null;
 	protected $block_json_files = null;
-	protected $block_json = array();
+	protected $block_json_validation = array();
 
 	/**
 	 * Constructor.

--- a/cli/class-import.php
+++ b/cli/class-import.php
@@ -567,7 +567,7 @@ class Import {
 	 *
 	 * @return string The plugin readme.txt or readme.md filename.
 	 */
-	protected function find_readme_file( $directory ) {
+	static function find_readme_file( $directory ) {
 		$files = Filesystem::list_files( $directory, false /* non-recursive */, '!^readme\.(txt|md)$!i' );
 
 		// prioritize readme.txt
@@ -587,7 +587,7 @@ class Import {
 	 *
 	 * @return object The plugin headers.
 	 */
-	protected function find_plugin_headers( $directory ) {
+	static function find_plugin_headers( $directory ) {
 		$files = Filesystem::list_files( $directory, false, '!\.php$!i' );
 
 		if ( ! function_exists( 'get_plugin_data' ) ) {
@@ -625,7 +625,7 @@ class Import {
 	 *
 	 * @return array An array of objects representing blocks, corresponding to the block.json format where possible.
 	 */
-	protected function find_blocks_in_file( $filename ) {
+	static function find_blocks_in_file( $filename ) {
 
 		$ext = strtolower( pathinfo($filename, PATHINFO_EXTENSION) );
 
@@ -660,7 +660,7 @@ class Import {
 		if ( 'block.json' === basename( $filename ) ) {
 			// A block.json file has everything we want.
 			$blockinfo = json_decode( file_get_contents( $filename ) );
-			if ( isset( $blockinfo->name ) && isset( $blockinfo->title ) ) {
+			if ( isset( $blockinfo->name ) ) {
 				$blocks[] = $blockinfo;
 			}
 		}
@@ -676,7 +676,7 @@ class Import {
 	 *
 	 * @return array
 	 */
-	protected function extract_file_paths_from_block_json( $parsed_json, $block_json_path = '' ) {
+	static function extract_file_paths_from_block_json( $parsed_json, $block_json_path = '' ) {
 		$files = array();
 
 		$props = array( 'editorScript', 'script', 'editorStyle', 'style' );

--- a/cli/class-import.php
+++ b/cli/class-import.php
@@ -569,7 +569,7 @@ class Import {
 	 * @return string The plugin readme.txt or readme.md filename.
 	 */
 	static function find_readme_file( $directory ) {
-		$files = Filesystem::list_files( $directory, false /* non-recursive */, '!^readme\.(txt|md)$!i' );
+		$files = Filesystem::list_files( $directory, false /* non-recursive */, '!(?:^|/)readme\.(txt|md)$!i' );
 
 		// prioritize readme.txt
 		foreach ( $files as $f ) {

--- a/shortcodes/class-block-validator.php
+++ b/shortcodes/class-block-validator.php
@@ -1,0 +1,85 @@
+<?php
+namespace WordPressdotorg\Plugin_Directory\Shortcodes;
+
+use WordPressdotorg\Plugin_Directory\CLI\Block_Plugin_Checker;
+
+class Block_Validator {
+
+	/**
+	 * Displays a form to validate block plugins.	
+	 */
+	public static function display() {
+		?>
+		<div class="wrap">
+<?php
+		error_log( var_export( $_POST, true ) );
+		if ( $_POST && wp_verify_nonce( $_POST['block-nonce'], 'validate-block-plugin' ) ) {
+
+				self::validate_block( $_POST['plugin_url'] );
+			}
+
+			$plugin_url      = $_REQUEST['plugin_url'] ?? '';
+			?>
+
+			<form method="post" action="">
+				<p>
+					<input type="text" name="plugin_url" size="70" placeholder="https://plugins.svn.wordpress.org/" value="<?php echo esc_url( $plugin_url ); ?>" />
+					<input type="submit" class="button button-secondary" value="<?php esc_attr_e( 'Validate!', 'wporg-plugins' ); ?>" />
+					<?php wp_nonce_field( 'validate-block-plugin', 'block-nonce' ); ?>
+				</p>
+			</form>
+
+		</div>
+		<?php
+	}
+
+	/**
+	 * Validates readme.txt contents and adds feedback.
+	 */
+	protected static function validate_block( $plugin_url ) {
+
+		$checker = new Block_Plugin_Checker();
+		$results = $checker->run_check_plugin_repo( $plugin_url );
+
+		if ( $checker->repo_url && $checker->repo_revision ) {
+			echo '<h2>Validating..</h2>';
+			echo '<p>Results for ' . esc_url( $checker->repo_url ) . ' revision ' . esc_html( $checker->repo_revision ) . '</p>';
+		}
+
+		$results_by_type = array();
+		foreach ( $results as $item ) {
+			$results_by_type[ $item->type ][] = $item;
+		}
+
+
+		$output = '';
+
+		$error_types = array(
+			'error'   => __( 'Fatal Errors:', 'wporg-plugins' ),
+			'warning' => __( 'Warnings:', 'wporg-plugins' ),
+			'info'    => __( 'Notes:', 'wporg-plugins' ),
+		);
+		foreach ( $error_types as $type => $warning_label ) {
+
+				if ( empty( $results_by_type[ $type ] ) )
+					continue;
+
+				$output .= "<h3>{$warning_label}</h3>\n";
+				$output .= "<div class='notice notice-{$type} notice-alt'>\n";
+				$output .= "<ul class='{$type}'>\n";
+				foreach ( $results_by_type[ $type ] as $item ) {
+					$output .= "<li title='{$item->check_name}'>{$item->check_name}: {$item->message}</li>\n";
+				}
+				$output .= "</ul>\n";
+				$output .= "</div>\n";
+		}
+
+		if ( empty( $output ) ) {
+			$output .= '<div class="notice notice-success notice-alt">';
+			$output .= '<p>' . __( 'Congratulations! No errors found.', 'wporg-plugins' ) . '</p>';
+			$output .= '</div>';
+		}
+
+		echo $output;
+	}
+}

--- a/shortcodes/class-block-validator.php
+++ b/shortcodes/class-block-validator.php
@@ -68,7 +68,7 @@ class Block_Validator {
 				$output .= "<div class='notice notice-{$type} notice-alt'>\n";
 				$output .= "<ul class='{$type}'>\n";
 				foreach ( $results_by_type[ $type ] as $item ) {
-					$output .= "<li title='{$item->check_name}'>{$item->check_name}: {$item->message}</li>\n";
+					$output .= "<li title='{$item->check_name}'><a href='/hypothetical/doc/page#{$item->check_name}'><span class='dashicons dashicons-info'></span></a> {$item->message}</li>\n";
 				}
 				$output .= "</ul>\n";
 				$output .= "</div>\n";


### PR DESCRIPTION
This adds a [block-validator] shortcode, based on the readme-validator, which runs a bunch of validation checks on block plugins. It incorporates @coreymckrill's `block.json` validator.

Also included is a CLI script, `bin/check-block.php`. If you run it without arguments, it will output validation results for all plugins currently in the block directory. Or use `php bin/check-block.php --slug waves` to run it on a single plugin.